### PR TITLE
Remove bogus parameter in KOHA.coce.getURL call

### DIFF
--- a/Koha/Plugin/Com/ByWaterSolutions/CoverFlow/report.tt
+++ b/Koha/Plugin/Com/ByWaterSolutions/CoverFlow/report.tt
@@ -52,7 +52,7 @@
 [% IF (use_coce) %]
 <script type="text/javascript" src="/opac-tmpl/bootstrap/js/coce.js"></script>
 <script type="text/javascript">
-      KOHA.coce.getURL('[% CoceHost %]', '[% CoceProviders %]',[% OPACURLOpenInNewWindow %]);
+      KOHA.coce.getURL('[% CoceHost %]', '[% CoceProviders %]');
 </script>
 [% END %]
 


### PR DESCRIPTION
Fixes #65

It looks like the third parameter used to be `newWindow`, but apparently it was a dead/unused variable: https://github.com/bywatersolutions/bywater-koha-future/blob/4d3314e0e4980e9f4224561a0f9bde9922b17e34/koha-tmpl/opac-tmpl/bootstrap/js/coce.js#L17

Nowadays it's replaced by `parent` parameter in upstream Koha, and passing a number there causes an error